### PR TITLE
Fix installer usage in README

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,15 @@ on:
   pull_request:
 
 jobs:
+  test-get-juvix-org:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run installer from get.juvix.org
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSfL https://get.juvix.org | sh -s -- -y
+          source ~/.local/share/juvix/env
+          juvix --help
+
   test-linux:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A shell script that installs the Juvix compiler binary for Linux and macOS.
 ## Usage
 
 ``` shell
-curl --proto '=https' --tlsv1.2 -sSf https://get.juvix.org | sh
+curl --proto '=https' --tlsv1.2 -sSfL https://get.juvix.org | sh
 ```
 
 ## macOS homebrew installer


### PR DESCRIPTION
https://get.juvix.org is a redirect so the `-L` option is required to instruct curl to follow it.

If `-L` is not specified then an empty body is passed to `sh` and the command is a no-op